### PR TITLE
Fix warnings relating to the deprecation of `Error::description`

### DIFF
--- a/src/coder/decoder.rs
+++ b/src/coder/decoder.rs
@@ -106,7 +106,12 @@ impl Decoder {
     /// The `input` signal (interleaved if 2 channels) will be encoded into the
     /// `output` payload and on success, returns the length of the
     /// encoded packet.
-    pub fn decode_float<'a, TP, TS>(&mut self, input: Option<TP>, output: TS, fec: bool) -> Result<usize>
+    pub fn decode_float<'a, TP, TS>(
+        &mut self,
+        input: Option<TP>,
+        output: TS,
+        fec: bool,
+    ) -> Result<usize>
     where
         TP: TryInto<Packet<'a>>,
         TS: TryInto<MutSignals<'a, f32>>,


### PR DESCRIPTION
The `Display` implementation on an error type is favoured over the `description` method on the `Error` trait, as it can provide additional information that may be useful when debugging.

It is also advised to use `source` over `cause`, as it can allow for proper downcasting to a concrete error type.