### PR TITLE
Fix documentation links

### DIFF
--- a/src/coder/encoder.rs
+++ b/src/coder/encoder.rs
@@ -462,7 +462,7 @@ impl Encoder {
     /// which still gives the encoder the freedom to reduce the bandpass when
     /// the bitrate becomes too low, for better overall quality.
     ///
-    /// [`set_max_bandwidth::Max`]: struct.Encoder.html#method.set_max_bandwidth
+    /// [`set_max_bandwidth`]: struct.Encoder.html#method.set_max_bandwidth
     pub fn set_bandwidth(&mut self, bandwidth: Bandwidth) -> Result<()> {
         self.set_encoder_ctl_request(ffi::OPUS_SET_BANDWIDTH_REQUEST, bandwidth as i32)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     ///
     /// [`SampleRate`]: ../enum.SampleRate.html
     InvalidSampleRate(i32),
-    /// A value failed to match a documented [`Channel`].
+    /// A value failed to match a documented [`Channels`].
     ///
     /// [`Channels`]: ../enum.Channels.html
     InvalidChannels(i32),


### PR DESCRIPTION
This fixes two links in the documentation that pointed to nothing. These were caught with the `-D broken_intra_doc_links` rustdoc flag.